### PR TITLE
Fix name fallback issue

### DIFF
--- a/color-picker.js
+++ b/color-picker.js
@@ -44,7 +44,7 @@ class ColorPicker extends cardTools.litElement() {
 
   render() {
     const html = cardTools.litHtml();
-    const name = this._config.name || (this.stateObj)?this.stateObj.attributes.friendly_name:null || this._config.entity;
+    const name = this._config.name || (this.stateObj?this.stateObj.attributes.friendly_name:null) || this._config.entity;
     return html`
       ${this.render_style()}
       <ha-card>


### PR DESCRIPTION
First of all, thank you for this nice card! 😄 But I had an issue with it, and here is the fix.

I defined a custom name for my element, but the card was displaying the default name.
Moving the parenthesis to the outer side of the ternary operation fixed the issue.